### PR TITLE
Disable SerivceAccount automount due to a bug in specific Kubernetes versions

### DIFF
--- a/ipcs/ipcs-backend.yaml
+++ b/ipcs/ipcs-backend.yaml
@@ -21,6 +21,8 @@ spec:
           persistentVolumeClaim:
             claimName: analysis-root-pvc
 
+      automountServiceAccountToken: false
+
       containers:
         - name: ipcs-tasks-high-priority
           image: registry-one.codescoring.ru/ipcs-huey
@@ -63,6 +65,8 @@ spec:
         - name: analysis-root
           persistentVolumeClaim:
             claimName: analysis-root-pvc
+
+      automountServiceAccountToken: false
 
       containers:
         - name: ipcs-tasks-high-priority-scheduler
@@ -107,6 +111,8 @@ spec:
           persistentVolumeClaim:
             claimName: analysis-root-pvc
 
+      automountServiceAccountToken: false
+
       containers:
         - name: ipcs-huey
           image: registry-one.codescoring.ru/ipcs-huey
@@ -149,6 +155,8 @@ spec:
         - name: analysis-root
           persistentVolumeClaim:
             claimName: analysis-root-pvc
+
+      automountServiceAccountToken: false
 
       containers:
         - name: ipcs-huey-scheduler
@@ -195,6 +203,8 @@ spec:
         - name: analysis-root
           persistentVolumeClaim:
             claimName: analysis-root-pvc
+
+      automountServiceAccountToken: false
 
       containers:
         - name: ipcs-backend

--- a/ipcs/ipcs-createbackup.yaml
+++ b/ipcs/ipcs-createbackup.yaml
@@ -38,6 +38,7 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: ipcs-createbackup
           image: registry-one.codescoring.ru/ipcs-backup:2022.48.1

--- a/ipcs/ipcs-createsuperuser.yaml
+++ b/ipcs/ipcs-createsuperuser.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   template:
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: ipcs-createsuperuser
           image: registry-one.codescoring.ru/ipcs-backend:2022.48.1

--- a/ipcs/ipcs-frontend.yaml
+++ b/ipcs/ipcs-frontend.yaml
@@ -17,6 +17,7 @@ spec:
         - name: django-static
           persistentVolumeClaim:
             claimName: django-static-pvc
+      automountServiceAccountToken: false
       containers:
         - name: ipcs-frontend
           image: registry-one.codescoring.ru/ipcs-frontend

--- a/ipcs/ipcs-migration.yaml
+++ b/ipcs/ipcs-migration.yaml
@@ -10,6 +10,7 @@ spec:
         - name: analysis-root
           persistentVolumeClaim:
             claimName: analysis-root-pvc
+      automountServiceAccountToken: false
       containers:
         - name: ipcs-migrate
           image: registry-one.codescoring.ru/ipcs-backend
@@ -40,6 +41,7 @@ spec:
         - name: django-static
           persistentVolumeClaim:
             claimName: django-static-pvc
+      automountServiceAccountToken: false
       containers:
         - name: ipcs-collectstatic
           image: registry-one.codescoring.ru/ipcs-backend

--- a/postgres/postgres.yaml
+++ b/postgres/postgres.yaml
@@ -93,6 +93,7 @@ spec:
       labels:
         app: postgres-container
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: postgres
           image: registry-one.codescoring.ru/postgres:13.4

--- a/redis/redis.yaml
+++ b/redis/redis.yaml
@@ -57,6 +57,7 @@ spec:
       labels:
         app: redis
     spec:
+      automountServiceAccountToken: false
       containers:
       - name: redis
         image: registry-one.codescoring.ru/redis:7.0.10


### PR DESCRIPTION
CodeScoring does not work with Kubernetes API, so `SeriviceAccount` token is not required in a `Pod`. This PR disables token auto-mounting to prevent bug in specific Kubernetes versions (see more - https://github.com/kubernetes/kubernetes/issues/105204)